### PR TITLE
Fix prefetching account metadata when working with multiple accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "accountable-vue",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "accountable-vue",
-			"version": "0.5.1",
+			"version": "0.5.2",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "accountable-vue",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"license": "GPL-3.0",
 	"description": "A Vue app for managing monetary assets.",
 	"scripts": {

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -6,7 +6,7 @@ defineProps({
 	to: { type: String as PropType<string | null>, default: null },
 	title: { type: String, required: true },
 	subtitle: { type: String as PropType<string | null>, default: null },
-	count: { type: Number as PropType<number | string | null>, default: null },
+	count: { type: [Number, String] as PropType<number | string | null>, default: null },
 	negative: { type: Boolean, default: false },
 });
 </script>

--- a/src/store/accountsStore.ts
+++ b/src/store/accountsStore.ts
@@ -80,6 +80,8 @@ export const useAccountsStore = defineStore("accounts", {
 				},
 				error => {
 					this.loadError = error;
+					if (this.accountsWatcher) this.accountsWatcher();
+					this.accountsWatcher = null;
 					console.error(error);
 				}
 			);

--- a/src/store/attachmentsStore.ts
+++ b/src/store/attachmentsStore.ts
@@ -78,6 +78,8 @@ export const useAttachmentsStore = defineStore("attachments", {
 				},
 				error => {
 					this.loadError = error;
+					if (this.attachmentsWatcher) this.attachmentsWatcher();
+					this.attachmentsWatcher = null;
 					console.error(error);
 				}
 			);

--- a/src/store/locationsStore.ts
+++ b/src/store/locationsStore.ts
@@ -73,6 +73,8 @@ export const useLocationsStore = defineStore("locations", {
 				},
 				error => {
 					this.loadError = error;
+					if (this.locationsWatcher) this.locationsWatcher();
+					this.locationsWatcher = null;
 					console.error(error);
 				}
 			);

--- a/src/store/tagsStore.ts
+++ b/src/store/tagsStore.ts
@@ -73,6 +73,8 @@ export const useTagsStore = defineStore("tags", {
 				},
 				error => {
 					this.loadError = error;
+					if (this.tagsWatcher) this.tagsWatcher();
+					this.tagsWatcher = null;
 					console.error(error);
 				}
 			);

--- a/src/transport/onSnapshot.ts
+++ b/src/transport/onSnapshot.ts
@@ -418,7 +418,7 @@ export function onSnapshot<T>(
 			} else if (event.code === WS_UNKNOWN) {
 				message += ": The server closed the connection without telling us why";
 			} else if (event.code === WS_GOING_AWAY) {
-				message += ": We're closing down for now";
+				message += ": Endpoint(s) closing down for now";
 			}
 			onErrorCallback(new Error(message));
 		}


### PR DESCRIPTION
* Fixed a bug where the Accounts list would fail to prefetch transactions in all accounts but one (if the user had more than one account)
* Probably fixed a bug that prevented watchers from restarting themselves in the event of failure