### PR TITLE
Native date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"bootstrap": "^5.1.3",
 				"btoa-lite": "^1.0.0",
 				"crypto-js": "^4.1.1",
+				"date-fns": "^2.28.0",
 				"dinero.js": "^2.0.0-alpha.8",
 				"fuse.js": "^6.4.6",
 				"lodash": "^4.17.21",
@@ -24,8 +25,7 @@
 				"uuid": "^8.3.2",
 				"vue": "^3.2.16",
 				"vue-router": "^4.0.11",
-				"vue-toastification": "^2.0.0-rc.1",
-				"vue3-date-time-picker": "^2.1.8"
+				"vue-toastification": "^2.0.0-rc.1"
 			},
 			"devDependencies": {
 				"@types/atob-lite": "^2.0.0",
@@ -2636,10 +2636,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
-			"integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==",
-			"dev": true,
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
 			"engines": {
 				"node": ">=0.11"
 			},
@@ -7858,17 +7857,6 @@
 				"typescript": "*"
 			}
 		},
-		"node_modules/vue3-date-time-picker": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/vue3-date-time-picker/-/vue3-date-time-picker-2.3.6.tgz",
-			"integrity": "sha512-nl9oYw2hLJoco6zBvQY/mAVF9c+j0jv6DWeBiuWDe3U9B5TRLgnYWfhCwkBCsRhEfMaE2fCCqhGd1aRaa5n8Ng==",
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"vue": ">=3.2.0"
-			}
-		},
 		"node_modules/w3c-hr-time": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -10118,10 +10106,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
-			"integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==",
-			"dev": true
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
 		},
 		"debug": {
 			"version": "4.3.3",
@@ -14037,12 +14024,6 @@
 				"@volar/shared": "0.31.4",
 				"vscode-vue-languageservice": "0.31.4"
 			}
-		},
-		"vue3-date-time-picker": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/vue3-date-time-picker/-/vue3-date-time-picker-2.3.6.tgz",
-			"integrity": "sha512-nl9oYw2hLJoco6zBvQY/mAVF9c+j0jv6DWeBiuWDe3U9B5TRLgnYWfhCwkBCsRhEfMaE2fCCqhGd1aRaa5n8Ng==",
-			"requires": {}
 		},
 		"w3c-hr-time": {
 			"version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "accountable-vue",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "accountable-vue",
-			"version": "0.5.6",
+			"version": "0.5.7",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "accountable-vue",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"license": "GPL-3.0",
 	"description": "A Vue app for managing monetary assets.",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"bootstrap": "^5.1.3",
 		"btoa-lite": "^1.0.0",
 		"crypto-js": "^4.1.1",
+		"date-fns": "^2.28.0",
 		"dinero.js": "^2.0.0-alpha.8",
 		"fuse.js": "^6.4.6",
 		"lodash": "^4.17.21",
@@ -38,8 +39,7 @@
 		"uuid": "^8.3.2",
 		"vue": "^3.2.16",
 		"vue-router": "^4.0.11",
-		"vue-toastification": "^2.0.0-rc.1",
-		"vue3-date-time-picker": "^2.1.8"
+		"vue-toastification": "^2.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@types/atob-lite": "^2.0.0",

--- a/src/transformers/toTimestamp.ts
+++ b/src/transformers/toTimestamp.ts
@@ -1,3 +1,6 @@
+/**
+ * @returns a timestamp string representing the date.
+ */
 export function toTimestamp(date: Date): string {
 	const formatter = new Intl.DateTimeFormat(undefined, {
 		dateStyle: "medium",
@@ -7,6 +10,9 @@ export function toTimestamp(date: Date): string {
 	return formatter.format(date);
 }
 
+/**
+ * @returns `true` if the current locale is a 12-hr formatting locale, instead of a 24-hr one.
+ */
 export function isLocale12Hr(): boolean {
 	// Initial idea from https://stackoverflow.com/a/60437579.
 	// Here, we default to 24-hr time because it's better, and


### PR DESCRIPTION
Client
* Use the browser's native date/time picker, now that there's a widely-accepted native one. Still need to handle time zones somehow, but at least this input knows that 1 May 2022 is a _Sunday_ and not a _Tuesday_ lol