### PR TITLE
Limit new users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "accountable-vue",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "accountable-vue",
-			"version": "0.6.1",
+			"version": "0.6.2",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "accountable-vue",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"license": "GPL-3.0",
 	"description": "A Vue app for managing monetary assets.",
 	"scripts": {

--- a/server/database/io.ts
+++ b/server/database/io.ts
@@ -127,6 +127,12 @@ async function destroyDbForUser(uid: string): Promise<void> {
 	await rm(folder, { recursive: true, force: true });
 }
 
+export async function numberOfUsers(): Promise<number> {
+	const data = await userIndexDb(data => data);
+	if (!data) return 0;
+	return Object.keys(data).length;
+}
+
 export async function fetchDbCollection(
 	ref: CollectionReference<AnyDataItem>
 ): Promise<Array<IdentifiedDataItem>> {

--- a/server/errors/NotEnoughRoomError.ts
+++ b/server/errors/NotEnoughRoomError.ts
@@ -1,11 +1,10 @@
 import { InternalError } from "./InternalError.js";
 
 export class NotEnoughRoomError extends InternalError {
-	constructor() {
-		super({
-			status: 507,
-			message: "There is not enough room to write your data. Delete some stuff first",
-		});
+	constructor(
+		message: string = "There is not enough room to write your data. Delete some stuff first"
+	) {
+		super({ status: 507, message });
 		this.name = "NotEnoughRoomError";
 	}
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "server",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "server",
-			"version": "0.4.0",
+			"version": "0.4.1",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",
 				"atob-lite": "^2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "server",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"scripts": {
 		"export-version": "./node_modules/.bin/genversion ./version.ts -es",
 		"prebuild": "rm -rf ./dist && npm run export-version",

--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -11,6 +11,7 @@ declare module "*.vue" {
 // See https://vitejs.dev/guide/env-and-mode.html
 interface ImportMetaEnv extends Readonly<Record<string, string>> {
 	readonly VITE_ACCOUNTABLE_SERVER_URL: string | undefined;
+	readonly VITE_ENABLE_SIGNUP: string | undefined;
 	readonly VITE_ENABLE_LOGIN: string | undefined;
 }
 

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -9,6 +9,8 @@ import { computed } from "vue";
 
 const aboutRoute = computed(() => aboutPath());
 const signupRoute = computed(() => signupPath());
+
+const isSignupEnabled = computed(() => import.meta.env.VITE_ENABLE_SIGNUP === "true");
 </script>
 
 <template>
@@ -20,9 +22,12 @@ const signupRoute = computed(() => signupPath());
 			<router-link :to="aboutRoute">
 				<ActionButton kind="bordered-secondary">Learn More</ActionButton>
 			</router-link>
-			<router-link :to="signupRoute">
+			<router-link v-if="isSignupEnabled" :to="signupRoute">
 				<ActionButton kind="bordered-primary-green">Get Started</ActionButton>
 			</router-link>
+			<a v-else href="#" @click.prevent>
+				<ActionButton kind="bordered-primary-green">Coming Soon&trade;</ActionButton>
+			</a>
 		</section>
 
 		<!-- Your money, where it's been -->

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -14,6 +14,8 @@ const ui = useUiStore();
 const router = useRouter();
 const route = useRoute();
 
+const isSignupEnabled = computed(() => import.meta.env.VITE_ENABLE_SIGNUP === "true");
+
 const isLoggedIn = computed(() => auth.uid !== null);
 const bootstrapError = computed(() => ui.bootstrapError);
 const accountId = ref("");
@@ -21,6 +23,7 @@ const password = ref("");
 const passwordRepeat = ref("");
 const isLoading = ref(false);
 const mode = computed<"login" | "signup">(() => {
+	if (!isSignupEnabled.value) return "login"; // can't sign up? log in instead.
 	return route.path === signupPath() ? "signup" : "login";
 });
 const isSignupMode = computed(() => mode.value === "signup");
@@ -173,11 +176,14 @@ async function submit() {
 			<span v-if="loginProcessState === 'DERIVING_PKEY'">Deriving key from passphrase...</span>
 
 			<div v-if="!isLoading">
-				<p v-if="isLoginMode"
+				<p v-if="!isSignupEnabled"
+					>Don't have an account? We'll be open for new accounts soon&trade;.</p
+				>
+				<p v-else-if="isLoginMode"
 					>Need to create an account?
 					<a href="#" @click.prevent="enterSignupMode">Create one!</a>
 				</p>
-				<p v-if="isSignupMode"
+				<p v-else-if="isSignupMode"
 					>Already have an account?
 					<a href="#" @click.prevent="enterLoginMode">Log in!</a>
 				</p>


### PR DESCRIPTION
I'm working on a bunch of stuff right now, and I can't (yet) afford a bigger host for Accountable. We can't fit many users, so I'm disabling new signups for now.

Client
* Add an env variable to toggle signup UI

Server
* The `/join` endpoint now respects the internal `MAX_USERS` variable to prevent new signups if we've exceeded the limit