### PR TITLE
Show balance progression for each transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "accountable-vue",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "accountable-vue",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "accountable-vue",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"license": "GPL-3.0",
 	"description": "A Vue app for managing monetary assets.",
 	"scripts": {

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -133,7 +133,7 @@ export function auth(this: void): Router {
 		)
 		.get(
 			"/session",
-			throttle(),
+			// throttle(),
 			asyncWrapper(async (req, res) => {
 				// ** If the user has the cookie set, respond with a JWT for the user
 

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -11,7 +11,7 @@ try {
 	allowedOrigins.add(host);
 } catch {} // nop
 
-process.stdout.write(`allowedOrigins: ${JSON.stringify(Array.from(allowedOrigins.values()))}\n`);
+process.stdout.write(`allowedOrigins: ${JSON.stringify(Array.from(allowedOrigins))}\n`);
 
 const corsOptions: CorsOptions = {
 	credentials: true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "server",
-	"version": "0.4.6",
+	"version": "0.4.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "server",
-			"version": "0.4.6",
+			"version": "0.4.7",
 			"dependencies": {
 				"@averagehelper/job-queue": "^1.0.1",
 				"atob-lite": "^2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "server",
-	"version": "0.4.6",
+	"version": "0.4.7",
 	"scripts": {
 		"export-version": "./node_modules/.bin/genversion ./version.ts -es",
 		"prebuild": "rm -rf ./dist && npm run export-version",

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -7,6 +7,7 @@ defineProps({
 	title: { type: String, required: true },
 	subtitle: { type: String as PropType<string | null>, default: null },
 	count: { type: [Number, String] as PropType<number | string | null>, default: null },
+	subCount: { type: String as PropType<string | null>, default: null },
 	negative: { type: Boolean, default: false },
 });
 </script>
@@ -22,7 +23,10 @@ defineProps({
 
 		<aside>
 			<slot name="aside" />
-			<span v-if="count !== null" class="count" :class="{ negative: negative }">{{ count }}</span>
+			<div class="counts">
+				<span v-if="count !== null" class="count" :class="{ negative: negative }">{{ count }}</span>
+				<span v-if="subCount !== null" class="subcount">{{ subCount }}</span>
+			</div>
 		</aside>
 
 		<Chevron class="chevron" />
@@ -67,9 +71,10 @@ defineProps({
 	aside {
 		display: flex;
 		flex-flow: row wrap;
+		align-items: center;
 		margin-left: auto;
 
-		> span {
+		span {
 			font-weight: bold;
 			min-width: 1em;
 			text-align: center;
@@ -79,14 +84,27 @@ defineProps({
 			margin-right: 8pt;
 		}
 
-		> .count {
-			background-color: color($gray);
-			color: color($inverse-label);
-			border-radius: 1em;
-			padding: 0 0.5em;
+		> .counts {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-end;
 
-			&.negative {
-				background-color: color($red);
+			> .count {
+				background-color: color($gray);
+				color: color($inverse-label);
+				border-radius: 1em;
+				padding: 0 0.5em;
+
+				&.negative {
+					background-color: color($red);
+				}
+			}
+
+			> .subcount {
+				font-size: small;
+				color: color($secondary-label);
+				margin-top: 4pt;
+				padding: 0 0.5em;
 			}
 		}
 	}

--- a/src/components/inputs/CurrencyInput.vue
+++ b/src/components/inputs/CurrencyInput.vue
@@ -7,6 +7,7 @@ import { dinero } from "dinero.js";
 import { intlFormat } from "../../transformers";
 import { ref, computed, toRefs, watch } from "vue";
 import { USD } from "@dinero.js/currencies";
+import { zeroDinero } from "../../helpers/dineroHelpers";
 
 const emit = defineEmits(["update:modelValue"]);
 
@@ -14,7 +15,7 @@ const props = defineProps({
 	label: { type: String as PropType<string | null>, default: null },
 	modelValue: {
 		type: Object as PropType<Dinero<number>>,
-		default: dinero({ amount: 0, currency: USD }),
+		default: zeroDinero,
 	},
 });
 const { modelValue } = toRefs(props);
@@ -22,7 +23,7 @@ const { modelValue } = toRefs(props);
 const isIncome = ref(false);
 
 const zeroValue = computed<string>(() => {
-	return intlFormat(dinero({ amount: 0, currency: USD }), "standard");
+	return intlFormat(zeroDinero, "standard");
 });
 const presentableValue = computed(() => {
 	return intlFormat(modelValue.value, "standard");

--- a/src/helpers/dineroHelpers.ts
+++ b/src/helpers/dineroHelpers.ts
@@ -1,0 +1,4 @@
+import { dinero } from "dinero.js";
+import { USD } from "@dinero.js/currencies";
+
+export const zeroDinero = dinero({ amount: 0, currency: USD });

--- a/src/model/Transaction.ts
+++ b/src/model/Transaction.ts
@@ -137,8 +137,7 @@ export function recordFromTransaction(transaction: Transaction): TransactionReco
 }
 
 export function addTagToTransaction(transaction: Transaction, tag: Tag): void {
-	const tagIdx = transaction.tagIds.indexOf(tag.id);
-	if (tagIdx === -1) {
+	if (!transaction.tagIds.includes(tag.id)) {
 		// tag not found, so add it!
 		transaction.tagIds.push(tag.id);
 	}
@@ -153,8 +152,7 @@ export function removeTagFromTransaction(transaction: Transaction, tag: Tag): vo
 }
 
 export function addAttachmentToTransaction(transaction: Transaction, file: Attachment): void {
-	const fileIdx = transaction.attachmentIds.indexOf(file.id);
-	if (fileIdx === -1) {
+	if (!transaction.attachmentIds.includes(file.id)) {
 		// file not found, so add it!
 		transaction.attachmentIds.push(file.id);
 	}

--- a/src/model/utility/sort.ts
+++ b/src/model/utility/sort.ts
@@ -8,3 +8,10 @@ type Created = Pick<Transaction | TransactionRecordParams, "createdAt">;
 export function reverseChronologically(this: void, a: Created, b: Created): number {
 	return b.createdAt.getTime() - a.createdAt.getTime();
 }
+
+/**
+ * A sort function that orders the given values in chronological order.
+ */
+export function chronologically(this: void, a: Created, b: Created): number {
+	return a.createdAt.getTime() - b.createdAt.getTime();
+}

--- a/src/pages/accounts/AccountView.vue
+++ b/src/pages/accounts/AccountView.vue
@@ -11,13 +11,13 @@ import SearchBar from "../../components/SearchBar.vue";
 import TransactionCreateModal from "../transactions/TransactionCreateModal.vue";
 import TransactionMonthListItem from "../transactions/TransactionMonthListItem.vue";
 import TransactionListItem from "../transactions/TransactionListItem.vue";
-import { dinero, isNegative as isDineroNegative } from "dinero.js";
 import { intlFormat } from "../../transformers";
+import { isNegative as isDineroNegative } from "dinero.js";
 import { ref, computed, toRefs, watch } from "vue";
 import { reverseChronologically } from "../../model/utility/sort";
-import { USD } from "@dinero.js/currencies";
 import { useAccountsStore, useTransactionsStore } from "../../store";
 import { useRoute, useRouter } from "vue-router";
+import { zeroDinero } from "../../helpers/dineroHelpers";
 
 const props = defineProps({
 	accountId: { type: String, required: true },
@@ -63,9 +63,7 @@ const filteredTransactions = computed<Array<Transaction>>(() =>
 );
 
 const remainingBalance = computed(() => accounts.currentBalance[accountId.value] ?? null);
-const isNegative = computed(() =>
-	isDineroNegative(remainingBalance.value ?? dinero({ amount: 0, currency: USD }))
-);
+const isNegative = computed(() => isDineroNegative(remainingBalance.value ?? zeroDinero));
 
 watch(
 	account,

--- a/src/pages/accounts/AccountView.vue
+++ b/src/pages/accounts/AccountView.vue
@@ -34,18 +34,24 @@ const isEditingTransaction = ref(false);
 
 const account = computed(() => accounts.items[accountId.value] ?? null);
 const theseTransactions = computed<Array<Transaction>>(() => {
-	const allTransactions = (transactions.transactionsForAccount[accountId.value] ??
-		{}) as Dictionary<Transaction>;
+	const allTransactions = transactions.transactionsForAccount[accountId.value] ?? {};
 	return Object.values(allTransactions).sort(reverseChronologically);
 });
+
 const transactionMonths = computed(() => {
+	const now = new Date();
 	const months = transactions.months;
 	return Object.entries(transactions.transactionsForAccountByMonth[accountId.value] ?? {}).sort(
-		([a], [b]) => {
-			const now = new Date();
+		([monthId1], [monthId2]) => {
 			// Look up the month's cached start date
-			const aStart = months[a]?.start ?? now;
-			const bStart = months[b]?.start ?? now;
+			const a = months[monthId1];
+			const b = months[monthId2];
+
+			if (!a) console.warn(`Month ${monthId1} (a) doesn't exist in cache`);
+			if (!b) console.warn(`Month ${monthId2} (b) doesn't exist in cache`);
+
+			const aStart = a?.start ?? now;
+			const bStart = b?.start ?? now;
 			// Order reverse chronologically
 			return bStart.getTime() - aStart.getTime();
 		}

--- a/src/pages/transactions/MonthView.vue
+++ b/src/pages/transactions/MonthView.vue
@@ -25,9 +25,7 @@ const month = computed<string | null>(() => {
 
 const monthTransactions = computed<Array<Transaction>>(() => {
 	if (month.value === null || !month.value) return [];
-	const byMonth = (transactions.transactionsForAccountByMonth[accountId.value] ?? {}) as Dictionary<
-		Array<Transaction>
-	>; // FIXME: This assertion shouldn't be necessary
+	const byMonth = transactions.transactionsForAccountByMonth[accountId.value] ?? {};
 	return byMonth[month.value] ?? [];
 });
 

--- a/src/pages/transactions/TransactionEdit.vue
+++ b/src/pages/transactions/TransactionEdit.vue
@@ -3,13 +3,13 @@ import type { Account } from "../../model/Account";
 import type { Location, LocationRecordParams } from "../../model/Location";
 import type { PropType } from "vue";
 import type { Transaction, TransactionRecordParams } from "../../model/Transaction";
-import { dinero, isNegative, isZero, toSnapshot } from "dinero.js";
+import { equal, isNegative, isZero, toSnapshot } from "dinero.js";
 import { recordFromLocation } from "../../model/Location";
 import { ref, computed, toRefs, onMounted } from "vue";
 import { transaction as newTransaction } from "../../model/Transaction";
-import { USD } from "@dinero.js/currencies";
 import { useI18n } from "vue-i18n";
 import { useLocationsStore, useTransactionsStore, useUiStore } from "../../store";
+import { zeroDinero } from "../../helpers/dineroHelpers";
 import ActionButton from "../../components/buttons/ActionButton.vue";
 import Checkbox from "../../components/inputs/Checkbox.vue";
 import CheckmarkIcon from "../../icons/Checkmark.vue";
@@ -47,7 +47,7 @@ const title = ref("");
 const notes = ref("");
 const locationData = ref<(LocationRecordParams & { id: string | null }) | null>(null);
 const createdAt = ref(new Date());
-const amount = ref(dinero({ amount: 0, currency: USD }));
+const amount = ref(zeroDinero);
 const isReconciled = ref(false);
 
 const isAskingToDelete = ref(false);
@@ -56,9 +56,7 @@ const hasAttachments = computed(() => (ogTransaction.value?.attachmentIds.length
 
 const hasChanges = computed(() => {
 	if (ogTransaction.value) {
-		const oldAmount = (
-			ogTransaction.value?.amount ?? dinero({ amount: 0, currency: USD })
-		).toJSON();
+		const oldAmount = (ogTransaction.value?.amount ?? zeroDinero).toJSON();
 		return (
 			createdAt.value !== (ogTransaction.value?.createdAt ?? new Date()) ||
 			title.value !== (ogTransaction.value?.title ?? "") ||
@@ -76,7 +74,7 @@ const hasChanges = computed(() => {
 	return (
 		title.value !== "" ||
 		notes.value !== "" ||
-		amount.value !== dinero({ amount: 0, currency: USD }) ||
+		!equal(amount.value, zeroDinero) ||
 		isReconciled.value !== false ||
 		(locationData.value?.title ?? "") !== "" ||
 		(locationData.value?.subtitle ?? "") !== "" ||

--- a/src/pages/transactions/TransactionListItem.vue
+++ b/src/pages/transactions/TransactionListItem.vue
@@ -5,9 +5,9 @@ import Checkbox from "../../components/inputs/Checkbox.vue";
 import ListItem from "../../components/ListItem.vue";
 import LocationIcon from "../../icons/Location.vue";
 import PaperclipIcon from "../../icons/Paperclip.vue";
-import { computed, ref, toRefs, onMounted } from "vue";
-import { intlFormat, toTimestamp } from "../../transformers";
 import { isNegative as isDineroNegative } from "dinero.js";
+import { computed, onMounted, ref, toRefs } from "vue";
+import { intlFormat, toTimestamp } from "../../transformers";
 import { transaction as newTransaction } from "../../model/Transaction";
 import { transactionPath } from "../../router";
 import { useAttachmentsStore, useTransactionsStore, useUiStore } from "../../store";
@@ -29,8 +29,8 @@ const hasLocation = computed(() => transaction.value.locationId !== null);
 const timestamp = computed(() => toTimestamp(transaction.value.createdAt));
 
 const accountBalanceSoFar = computed(() => {
-	const balances = transactions.accountBalancesForTransaction[transaction.value.accountId] ?? {};
-	return balances[transaction.value.id] ?? null;
+	const allBalancesForAccount = transactions.allBalances[transaction.value.accountId] ?? {};
+	return allBalancesForAccount[transaction.value.id] ?? null;
 });
 
 const transactionRoute = computed(() =>
@@ -55,7 +55,6 @@ function seeIfAnyAttachmentsAreBroken() {
 
 onMounted(() => {
 	seeIfAnyAttachmentsAreBroken();
-	void transactions.computeBalanceAfterTransaction(transaction.value);
 });
 
 async function markReconciled(isReconciled: boolean) {

--- a/src/pages/transactions/TransactionListItem.vue
+++ b/src/pages/transactions/TransactionListItem.vue
@@ -28,6 +28,11 @@ const isAttachmentBroken = ref<boolean | "unknown">("unknown");
 const hasLocation = computed(() => transaction.value.locationId !== null);
 const timestamp = computed(() => toTimestamp(transaction.value.createdAt));
 
+const accountBalanceSoFar = computed(() => {
+	const balances = transactions.accountBalancesForTransaction[transaction.value.accountId] ?? {};
+	return balances[transaction.value.id] ?? null;
+});
+
 const transactionRoute = computed(() =>
 	transactionPath(transaction.value.accountId, transaction.value.id)
 );
@@ -50,6 +55,7 @@ function seeIfAnyAttachmentsAreBroken() {
 
 onMounted(() => {
 	seeIfAnyAttachmentsAreBroken();
+	void transactions.computeBalanceAfterTransaction(transaction.value);
 });
 
 async function markReconciled(isReconciled: boolean) {
@@ -73,6 +79,7 @@ async function markReconciled(isReconciled: boolean) {
 		:title="transaction.title ?? '--'"
 		:subtitle="timestamp"
 		:count="intlFormat(transaction.amount)"
+		:sub-count="accountBalanceSoFar ? intlFormat(accountBalanceSoFar) : '--'"
 		:negative="isNegative"
 	>
 		<template #icon>

--- a/src/pages/transactions/TransactionView.vue
+++ b/src/pages/transactions/TransactionView.vue
@@ -180,6 +180,11 @@ async function onFileReceived(file: File) {
 			<span class="key">Timestamp</span>
 			<span class="value">{{ timestamp }}</span>
 		</div>
+		<!-- Reconciliation -->
+		<div class="key-value-pair" aria-label="Is Transaction Reconciled?">
+			<span class="key">Reconciled</span>
+			<span class="value">{{ transaction.isReconciled ? "Yes" : "No" }}</span>
+		</div>
 		<!-- Account -->
 		<div class="key-value-pair" aria-label="Transaction Account">
 			<span class="key">Account</span>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -93,9 +93,10 @@ export const useAuthStore = defineStore("auth", {
 		async onSignedOut() {
 			this.clearCache();
 
-			const { accounts, attachments, tags, transactions } = await stores();
+			const { accounts, attachments, locations, tags, transactions } = await stores();
 			accounts.clearCache();
 			attachments.clearCache();
+			locations.clearCache();
 			tags.clearCache();
 			transactions.clearCache();
 		},

--- a/src/store/transactionsStore.ts
+++ b/src/store/transactionsStore.ts
@@ -5,15 +5,15 @@ import type { Location } from "../model/Location";
 import type { Transaction, TransactionRecordParams } from "../model/Transaction";
 import type { TransactionSchema } from "../model/DatabaseSchema";
 import type { Tag } from "../model/Tag";
-import { dinero, add, subtract } from "dinero.js";
+import { add, subtract } from "dinero.js";
 import { defineStore } from "pinia";
 import { getDocs } from "../transport/index.js";
 import { reverseChronologically } from "../model/utility/sort";
 import { stores } from "./stores";
-import { USD } from "@dinero.js/currencies";
 import { useAccountsStore } from "./accountsStore";
 import { useAuthStore } from "./authStore";
 import { useUiStore } from "./uiStore";
+import { zeroDinero } from "../helpers/dineroHelpers";
 import chunk from "lodash/chunk";
 import groupBy from "lodash/groupBy";
 import {
@@ -101,8 +101,7 @@ export const useTransactionsStore = defineStore("transactions", {
 					// Update cache
 					snap.docChanges().forEach(change => {
 						const accountTransactions = this.transactionsForAccount[account.id] ?? {};
-						let currentBalance =
-							accounts.currentBalance[account.id] ?? dinero({ amount: 0, currency: USD });
+						let currentBalance = accounts.currentBalance[account.id] ?? zeroDinero;
 
 						try {
 							switch (change.type) {
@@ -110,8 +109,7 @@ export const useTransactionsStore = defineStore("transactions", {
 									// Update the account's balance total
 									currentBalance = subtract(
 										currentBalance,
-										accountTransactions[change.doc.id]?.amount ??
-											dinero({ amount: 0, currency: USD })
+										accountTransactions[change.doc.id]?.amount ?? zeroDinero
 									);
 									// Forget this transaction
 									delete accountTransactions[change.doc.id];
@@ -125,8 +123,7 @@ export const useTransactionsStore = defineStore("transactions", {
 									// Update the account's balance total
 									currentBalance = add(
 										currentBalance,
-										accountTransactions[change.doc.id]?.amount ??
-											dinero({ amount: 0, currency: USD })
+										accountTransactions[change.doc.id]?.amount ?? zeroDinero
 									);
 									break;
 								}
@@ -135,8 +132,7 @@ export const useTransactionsStore = defineStore("transactions", {
 									// Remove this account's balance total
 									currentBalance = subtract(
 										currentBalance,
-										accountTransactions[change.doc.id]?.amount ??
-											dinero({ amount: 0, currency: USD })
+										accountTransactions[change.doc.id]?.amount ?? zeroDinero
 									);
 									// Update this transaction
 									const transaction = transactionFromSnapshot(change.doc, dek);
@@ -145,8 +141,7 @@ export const useTransactionsStore = defineStore("transactions", {
 									// Update this account's balance total
 									currentBalance = add(
 										currentBalance,
-										accountTransactions[change.doc.id]?.amount ??
-											dinero({ amount: 0, currency: USD })
+										accountTransactions[change.doc.id]?.amount ?? zeroDinero
 									);
 									break;
 								}
@@ -207,7 +202,7 @@ export const useTransactionsStore = defineStore("transactions", {
 				(balance, transaction) => {
 					return add(balance, transaction.amount);
 				},
-				dinero({ amount: 0, currency: USD })
+				zeroDinero
 			);
 
 			this.transactionsForAccount[account.id] = transactions;

--- a/src/store/transactionsStore.ts
+++ b/src/store/transactionsStore.ts
@@ -180,8 +180,8 @@ export const useTransactionsStore = defineStore("transactions", {
 						// Sort each transaction list
 						groupedTransactions[month]?.sort(reverseChronologically);
 					}
+					this.months = months; // save months before we save transactions, so components know how to sort things
 					this.transactionsForAccountByMonth[account.id] = groupedTransactions;
-					this.months = months;
 				},
 				error => {
 					console.error(error);

--- a/src/store/transactionsStore.ts
+++ b/src/store/transactionsStore.ts
@@ -67,6 +67,7 @@ export const useTransactionsStore = defineStore("transactions", {
 			Object.values(this.transactionsWatchers).forEach(unsubscribe => unsubscribe());
 			this.transactionsWatchers = {};
 			this.transactionsForAccount = {};
+			this.transactionsForAccountByMonth = {};
 			console.debug("transactionsStore: cache cleared");
 		},
 		async watchTransactions(account: Account, force: boolean = false) {

--- a/src/transformers/simplifiedByteCount.ts
+++ b/src/transformers/simplifiedByteCount.ts
@@ -34,11 +34,13 @@ export function simplifiedByteCount(num: number, locale?: LocaleCode): string {
 	 */
 	const units = ["byte", "kilobyte", "megabyte", "gigabyte", "terabyte", "petabyte"] as const;
 
+	type Unit = typeof units[number];
+
 	// Get the nearest applicable unit
 	const exponent: number =
 		num > 0 ? Math.min(Math.floor(Math.log(num) / Math.log(1000)), units.length - 1) : 0;
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const unit = units[exponent] ?? units[units.length - 1]!;
+	const unit: Unit = units[exponent] ?? units[units.length - 1]!;
 	// ASSUMPTION: The `units` array is never empty
 
 	// Set up a unit formatter for the selected locale


### PR DESCRIPTION
### Client
* We now properly clear the location and transaction caches on lock/logout
* We now show what the account's balance was at each transaction.
* Transactions now show their `isReconciled` status on their detail page.
* We now sort months more consistently in reverse-chronological order. For real this time. (Probably.)
* Some smol code helps to make certain things easier to implement

### Server
* Disabled throttling on the `GET /session` endpoint. It was getting annoying having to restart the server every other time I refreshed the page. I'll re-enable throttling there after some rethinking.